### PR TITLE
Use source code at hand to build Docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+.dockerignore
+.git
+.github
+.travis.yml
+LICENSE
+tests

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,9 +28,8 @@ RUN pip install --upgrade setuptools
 RUN pip install annot_utils==0.2.0
 RUN pip install pysam==0.13
 
-RUN git clone -b feature/no-blat https://github.com/chrovis-genomon/fusionfusion.git && \
-    cd fusionfusion && \
-    python setup.py install
+COPY . /root/fusionfusion
+RUN cd /root/fusionfusion && python setup.py install
 
 RUN pip install chimera_utils==0.4.1
 


### PR DESCRIPTION
This PR modifies Dockerfile to build a Docker image based on the source code in the repository, instead of cloning a specific branch of the repository. This enables us to make Docker images that reflect the content of each branch or commit.