### PR TITLE
Short range chimera filter, revised

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,14 @@ For STAR, our software uses the chimeric sam file
 {output_prefix}.Chimeric.out.sam
 ```
 
+Optionally, you can specify the following files to enable further analysis (Note that
+the aligned bam must be sorted by coordinate):
+
+```
+{output_prefix}.SJ.out.tab
+{output_prefix}.Aligned.sortedByCoord.out.bam
+```
+
 For MapSplice2, our software uses the read alignment file
 ```
 alignments.sam (bam)
@@ -73,6 +81,8 @@ fusionfusion [-h] [--version] [--star star.Chimeric.out.sam]
                   [--min_allowed_contig_match_diff MIN_ALLOWED_CONTIG_MATCH_DIFF]
                   [--check_contig_size_other_breakpoint CHECK_CONTIG_SIZE_OTHER_BREAKPOINT]
                   [--filter_same_gene]
+                  [--star_sj_tab star.SJ.out.tab]
+                  [--star_aligned_bam star.Aligned.sortedByCoord.out.bam]
 ```
 At least one of --star, --ms2, --th2 arguments should be specified.
 The arguments of --out and --reference_genome are mandatory. 

--- a/fusionfusion/annotationFunction.py
+++ b/fusionfusion/annotationFunction.py
@@ -1,7 +1,7 @@
 #! /usr/bin/env python
 
 from __future__ import print_function
-import sys, pysam, os, subprocess
+import sys, pysam, os, subprocess, re
 import annot_utils.gene
 import annot_utils.exon
 
@@ -271,4 +271,28 @@ def merge_fusion_result(input_dir, output_file_path):
     hOUT.close()
 
     subprocess.check_call(["rm", "-rf", output_file_path + ".unsorted.tmp"])
+
+    trace_files = list(filter(os.path.exists, [
+        input_dir + "/star.chimeric.trace.txt",
+        # input_dir + "/ms2.chimeric.trace.txt",
+        # input_dir + "/th2.chimeric.trace.txt"
+    ]))
+    if trace_files:
+        traced_file_path = re.sub('(?:\.txt)?$', '.traced.txt', output_file_path, count=1)
+        emit_traced(output_file_path, trace_files, traced_file_path)
  
+def emit_traced(input_file, trace_files, output_file):
+    trace = {}
+    for trace_file in trace_files:
+        with open(trace_file) as t:
+            for line in t:
+                cols = line.rstrip().split('\t')
+                if cols[7] != '---':
+                    trace[tuple(cols[0:7])] = cols[7]
+
+    with open(input_file) as r, open(output_file, 'w') as w:
+        for line in r:
+            cols = line.rstrip().split('\t')
+            source = trace.get(tuple(cols[0:7]), '---')
+            cols.append(source)
+            print('\t'.join(cols), file=w)

--- a/fusionfusion/arg_parser.py
+++ b/fusionfusion/arg_parser.py
@@ -16,6 +16,12 @@ def create_parser():
     parser.add_argument("--star", metavar = "star.Chimeric.out.sam", default = None, type = str,
                         help = "the path to the chimeric sam file by STAR")
 
+    parser.add_argument("--star_sj_tab", metavar = "star.SJ.out.tab", default = None, type = str,
+                        help = "the path to the SJ.out.tab file by STAR")
+
+    parser.add_argument("--star_aligned_bam", metavar = "star.Aligned.sortedByCoord.out.bam", default = None, type = str,
+                        help = "the path to the aligned bam file by STAR (which must be sorted by coordinate)")
+
     parser.add_argument("--ms2", metavar = "ms2.bam", default = None, type = str,
                         help = "the path to the bam file by Map splice2")
 

--- a/fusionfusion/filterJunctionInfo.py
+++ b/fusionfusion/filterJunctionInfo.py
@@ -131,13 +131,15 @@ def filterPoolControl(input_file, output_file, control_file):
     hout.close()
 
 
-def extractSplicingPattern(inputFilePath, outputFilePath):
+def extractSplicingPattern(inputFilePath, outputFilePath, traceFilePath):
 
     # reference_genome = config.param_conf.get("alignment", "reference_genome")
     reference_genome = param_conf.reference_genome
 
     hIN = open(inputFilePath, 'r')
     hOUT = open(outputFilePath, 'w')
+    if traceFilePath:
+        hTRACE = open(traceFilePath, 'w')
 
     for line in hIN:
         F = line.rstrip('\n').split('\t')
@@ -477,11 +479,24 @@ def extractSplicingPattern(inputFilePath, outputFilePath):
         if F[2] == "+": contigSeq1 = seq_utils.reverseComplement(contigSeq1)
         if F[5] == "+": contigSeq2 = seq_utils.reverseComplement(contigSeq2)
 
-        print('\t'.join(['\t'.join(F[0:6]), str(inSeq), str(len(F[8].split(';'))), str(contig1), str(contig2), contigSeq1, contigSeq2]), file = hOUT)
-
+        common_cols = F[0:6] + [str(inSeq)]
+        out_cols = common_cols + [
+            str(len(F[8].split(';'))), str(contig1), str(contig2),
+            contigSeq1, contigSeq2
+        ]
+        print('\t'.join(out_cols), file=hOUT)
+        if traceFilePath:
+            sources = set()
+            for qname in F[7].split(';'):
+                m = re.search('@([^@]+)$', qname)
+                if m: sources.add(m.group(1))
+            trace_cols = common_cols + [','.join(sources) if sources else '---']
+            print('\t'.join(trace_cols), file=hTRACE)
 
     hIN.close()
     hOUT.close()
+    if traceFilePath:
+        hTRACE.close()
 
 
 

--- a/fusionfusion/parseJunctionInfo.py
+++ b/fusionfusion/parseJunctionInfo.py
@@ -343,7 +343,7 @@ def parseJuncInfo_th2(inputFilePath, outputFilePath):
     hOUT.close()
 
 
-def getFusInfo_STAR(juncLine):
+def getFusInfo_STAR(juncLine, source=None):
 
     # abnormal_insert_size = config.param_conf.getint("parse_condition", "abnormal_insert_size")
     # min_major_clip_size = config.param_conf.getint("parse_condition", "min_major_clip_size")
@@ -409,7 +409,11 @@ def getFusInfo_STAR(juncLine):
             coverRegion_primary = cigar_utils.getCoverRegion(F[2], F[3], F[5])
             readLength_primary = len(F[9])
             endPos_primary = cigar_utils.getEndPos(pos_primary, F[5])
-            readID_primary = F[0] + ("/1" if flags[6] == "1" else "/2")
+            readID_primary = "{qname}/{read}{suffix}".format(
+                qname=F[0],
+                read=(1 if flags[6] == "1" else 2),
+                suffix=("@" + source if source else "")
+            )
 
             tempMatch = cigarSRe_right.search(F[5])
             if tempMatch is not None: right_clipping_primary = int(tempMatch.group(1))
@@ -574,7 +578,7 @@ def getFusInfo_STAR(juncLine):
 
 
 
-def parseJuncInfo_STAR(inputFilePath, outputFilePath):
+def parseJuncInfo_STAR(inputFilePath, outputFilePath, source=None):
 
      
     hIN = open(inputFilePath, 'r')
@@ -589,7 +593,7 @@ def parseJuncInfo_STAR(inputFilePath, outputFilePath):
 
         if tempID != F[0]:
             if tempID != "" and len(tempLine) == 3:
-                tempFusInfo = getFusInfo_STAR(tempLine)
+                tempFusInfo = getFusInfo_STAR(tempLine, source)
                 if tempFusInfo is not None:
                     print(tempFusInfo, file = hOUT)
 
@@ -602,7 +606,7 @@ def parseJuncInfo_STAR(inputFilePath, outputFilePath):
 
 
     if tempID != "" and len(tempLine) == 3:
-        tempFusInfo = getFusInfo_STAR(tempLine)
+        tempFusInfo = getFusInfo_STAR(tempLine, source)
         if tempFusInfo is not None:
             print(tempFusInfo, file = hOUT)
 

--- a/fusionfusion/run.py
+++ b/fusionfusion/run.py
@@ -2,11 +2,13 @@
 
 from __future__ import print_function
 
-import sys, os, argparse, subprocess, shutil
+import sys, os, argparse, subprocess, shutil, pysam
+import annot_utils as annot
 from . import parseJunctionInfo
 from . import filterJunctionInfo
 from . import annotationFunction
 from . import utils
+from .short_range_chimera_filter import ShortRangeChimeraFilter
 
 # import config
 from .config import *
@@ -135,17 +137,62 @@ def fusionfusion_main(args):
     # parsing chimeric reads from bam files
     if starBamFile is not None:
 
-        parseJunctionInfo.parseJuncInfo_STAR(starBamFile, output_dir + "/star.chimeric.tmp.txt")
-                                             
+        starSjTab = args.star_sj_tab
+        starAlignedBam = args.star_aligned_bam
+        if starSjTab is None or starAlignedBam is None:
+            if starSjTab is not None or starAlignedBam is not None:
+                msg = "To enable further analysis using STAR's SJ.out.tab, both --star_sj_tab and --star_aligned_bam options must be specified."
+                print(msg, file=sys.stderr)
 
-        hOUT = open(output_dir + "/star.chimeric.txt", "w")
-        subprocess.check_call(["sort", "-k1,1", "-k2,2n", "-k4,4", "-k5,5n", output_dir + "/star.chimeric.tmp.txt"], stdout = hOUT)
-        hOUT.close()
+            parseJunctionInfo.parseJuncInfo_STAR(starBamFile, output_dir + "/star.chimeric.tmp.txt")
+
+            with open(output_dir + "/star.chimeric.txt", "w") as hOUT:
+                subprocess.check_call([
+                    "sort", "-k1,1", "-k2,2n", "-k4,4", "-k5,5n",
+                    output_dir + "/star.chimeric.tmp.txt"
+                ], stdout=hOUT)
+        else:
+            parseJunctionInfo.parseJuncInfo_STAR(starBamFile, output_dir + "/star.chimeric.tmp1.txt")
+
+            genome_id = args.genome_id
+            is_grc = args.grc
+            annot.gene.make_gene_info(output_dir + "/star.tmp.refGene.bed.gz", "refseq", genome_id, is_grc, False)
+            annot.gene.make_gene_info(output_dir + "/star.tmp.ensGene.bed.gz", "gencode", genome_id, is_grc, False)
+
+            with pysam.TabixFile(output_dir + "/star.tmp.refGene.bed.gz") as ref_gene_tb, \
+                pysam.TabixFile(output_dir + "/star.tmp.ensGene.bed.gz") as ens_gene_tb:
+                filt = ShortRangeChimeraFilter(ref_gene_tb, ens_gene_tb)
+                filt.run(starSjTab, starAlignedBam, output_dir + "/star.chimeric.tmp2.sam")
+            subprocess.check_call(["rm", output_dir + "/star.tmp.refGene.bed.gz"])
+            subprocess.check_call(["rm", output_dir + "/star.tmp.ensGene.bed.gz"])
+            subprocess.check_call(["rm", output_dir + "/star.tmp.refGene.bed.gz.tbi"])
+            subprocess.check_call(["rm", output_dir + "/star.tmp.ensGene.bed.gz.tbi"])
+
+            pysam.sort(
+                "-n",
+                "-o", output_dir + "/star.chimeric.tmp2.sorted.sam",
+                output_dir + "/star.chimeric.tmp2.sam"
+            )
+            parseJunctionInfo.parseJuncInfo_STAR(output_dir + "/star.chimeric.tmp2.sorted.sam",
+                                                 output_dir + "/star.chimeric.tmp2.txt")
+
+            with open(output_dir + "/star.chimeric.txt", "w") as hOUT:
+                subprocess.check_call([
+                    "sh", "-c",
+                    "cat {input1} {input2} | sort -k1,1 -k2,2n -k4,4 -k5,5n".format(
+                        input1=output_dir + "/star.chimeric.tmp1.txt",
+                        input2=output_dir + "/star.chimeric.tmp2.txt"
+                    )
+                ], stdout=hOUT)
 
         cluster_filter_junction(output_dir + "/star.chimeric.txt", output_dir + "/star", args)
 
         if debug_mode == False:
-            subprocess.check_call(["rm", output_dir + "/star.chimeric.tmp.txt"])
+            subprocess.check_call(["rm", "-f", output_dir + "/star.chimeric.tmp.txt"])
+            subprocess.check_call(["rm", "-f", output_dir + "/star.chimeric.tmp1.txt"])
+            subprocess.check_call(["rm", "-f", output_dir + "/star.chimeric.tmp2.txt"])
+            subprocess.check_call(["rm", "-f", output_dir + "/star.chimeric.tmp2.sam"])
+            subprocess.check_call(["rm", "-f", output_dir + "/star.chimeric.tmp2.sorted.sam"])
             subprocess.check_call(["rm", output_dir + "/star.chimeric.txt"])
 
     if ms2BamFile is not None:

--- a/fusionfusion/run.py
+++ b/fusionfusion/run.py
@@ -13,7 +13,7 @@ from .short_range_chimera_filter import ShortRangeChimeraFilter
 # import config
 from .config import *
 
-def cluster_filter_junction(inputFilePath, outputFilePrefix, args):
+def cluster_filter_junction(inputFilePath, outputFilePrefix, args, generates_trace=False):
 
     # debug_mode = config.param_conf.getboolean("debug", "debug_mode")
     debug_mode = param_conf.debug
@@ -32,8 +32,10 @@ def cluster_filter_junction(inputFilePath, outputFilePrefix, args):
         shutil.copyfile(outputFilePrefix + ".chimeric.clustered.filt1.txt",
                          outputFilePrefix + ".chimeric.clustered.filt2.txt")
 
+    traceFilePath = outputFilePrefix + ".chimeric.trace.txt" if generates_trace else None
     filterJunctionInfo.extractSplicingPattern(outputFilePrefix + ".chimeric.clustered.filt2.txt", 
-                                              outputFilePrefix + ".chimeric.clustered.splicing.txt")
+                                              outputFilePrefix + ".chimeric.clustered.splicing.txt",
+                                              traceFilePath)
 
     if args.no_blat:
         annotationFunction.filterAndAnnotation(
@@ -136,7 +138,7 @@ def fusionfusion_main(args):
     ####################
     # parsing chimeric reads from bam files
     if starBamFile is not None:
-
+        generates_trace = False
         starSjTab = args.star_sj_tab
         starAlignedBam = args.star_aligned_bam
         if starSjTab is None or starAlignedBam is None:
@@ -152,7 +154,9 @@ def fusionfusion_main(args):
                     output_dir + "/star.chimeric.tmp.txt"
                 ], stdout=hOUT)
         else:
-            parseJunctionInfo.parseJuncInfo_STAR(starBamFile, output_dir + "/star.chimeric.tmp1.txt")
+            parseJunctionInfo.parseJuncInfo_STAR(starBamFile,
+                                                 output_dir + "/star.chimeric.tmp1.txt",
+                                                 source="Chimeric")
 
             genome_id = args.genome_id
             is_grc = args.grc
@@ -174,7 +178,8 @@ def fusionfusion_main(args):
                 output_dir + "/star.chimeric.tmp2.sam"
             )
             parseJunctionInfo.parseJuncInfo_STAR(output_dir + "/star.chimeric.tmp2.sorted.sam",
-                                                 output_dir + "/star.chimeric.tmp2.txt")
+                                                 output_dir + "/star.chimeric.tmp2.txt",
+                                                 source="SJ")
 
             with open(output_dir + "/star.chimeric.txt", "w") as hOUT:
                 subprocess.check_call([
@@ -185,7 +190,10 @@ def fusionfusion_main(args):
                     )
                 ], stdout=hOUT)
 
-        cluster_filter_junction(output_dir + "/star.chimeric.txt", output_dir + "/star", args)
+            generates_trace = True
+
+        cluster_filter_junction(output_dir + "/star.chimeric.txt", output_dir + "/star",
+                                args, generates_trace=generates_trace)
 
         if debug_mode == False:
             subprocess.check_call(["rm", "-f", output_dir + "/star.chimeric.tmp.txt"])
@@ -243,4 +251,7 @@ def fusionfusion_main(args):
     annotationFunction.merge_fusion_result(output_dir, 
                                            output_dir + "/fusion_fusion.result.txt")
 
-    
+    if not debug_mode:
+        subprocess.check_call(["rm", "-f", output_dir + "/star.chimeric.trace.txt"])
+        # subprocess.check_call(["rm", "-f", output_dir + "/ms2.chimeric.trace.txt"])
+        # subprocess.check_call(["rm", "-f", output_dir + "/th2.chimeric.trace.txt"])

--- a/fusionfusion/short_range_chimera_filter.py
+++ b/fusionfusion/short_range_chimera_filter.py
@@ -1,0 +1,125 @@
+import collections
+import copy
+import itertools
+import pysam
+
+from . import annotationFunction
+
+class ShortRangeChimeraFilter:
+    def __init__(self, ref_gene_tb, ens_gene_tb):
+        self.ref_gene_tb = ref_gene_tb
+        self.ens_gene_tb = ens_gene_tb
+        self.interval = 500
+
+    def run(self, splicing_file, bam_file, output_file):
+        with open(splicing_file) as splicing_reader, \
+             pysam.AlignmentFile(bam_file, 'r') as bam_reader, \
+             pysam.AlignmentFile(output_file, 'w', header=bam_reader.header) as sam_writer:
+            for chr, start, end in self.load_splicing_junctions(splicing_reader):
+                pair_alns = collections.defaultdict(set)
+                for aln in self.load_alignments(bam_reader, chr, start, end):
+                    locus = (aln.reference_name, aln.reference_start)
+                    entry = (aln.query_name, aln.is_read1)
+                    if entry in pair_alns[locus]:
+                        self.write_alignment(sam_writer, aln, chr, start, end)
+                        pair_alns[locus].remove(entry)
+                    else:
+                        aln1, aln2 = self.split_alignment(aln, start)
+                        self.write_alignment(sam_writer, aln1, chr, start, end)
+                        self.write_alignment(sam_writer, aln2, chr, start, end)
+                        next_locus = (aln.next_reference_name, aln.next_reference_start)
+                        next_entry = (aln.query_name, not aln.is_read1)
+                        pair_alns[next_locus].add(next_entry)
+                # fetch and write pair reads
+                for aln in self.load_pair_alignments(bam_reader, pair_alns):
+                    self.write_alignment(sam_writer, aln, chr, start, end)
+
+    def write_alignment(self, sam_writer, aln, chr, start, end):
+        # Strip tags since they are unnecessary for succeeding processes
+        aln.set_tags([])
+        aln.query_name += '_{}:{}-{}'.format(chr, start, end+1)
+        sam_writer.write(aln)
+
+    def get_genes_at(self, chr, pos):
+        return set(annotationFunction.get_gene_info(chr, pos, self.ref_gene_tb, self.ens_gene_tb))
+
+    def load_splicing_junctions(self, splicing_reader):
+        for line in splicing_reader:
+            chr, start, end = line.split('\t')[:3]
+            start_genes = self.get_genes_at(chr, start)
+            end_genes = self.get_genes_at(chr, end)
+            if not(start_genes.intersection(end_genes)):
+                yield (chr, int(start)-1, int(end))
+
+    def load_alignments(self, bam_reader, chr, start, end):
+        def pairwise(it):
+            it1, it2 = itertools.tee(it)
+            next(it2, None)
+            return zip(it1, it2)
+
+        for aln in bam_reader.fetch(chr, start, start+1):
+            if not aln.is_proper_pair or aln.is_secondary: continue
+
+            for (_, curr_end), (next_start, _) in pairwise(aln.get_blocks()):
+                if curr_end == start and next_start == end:
+                    break
+            else:
+                continue
+            yield aln
+
+    def load_pair_alignments(self, bam_reader, pair_alns):
+        def chunked(alns, interval):
+            chrom = start = end = None
+            entries = set()
+            for (chr, pos), es in sorted(alns.items(), key=lambda x: x[0]):
+                if chrom == chr and pos <= start + interval:
+                    end = pos
+                    entries.update(es)
+                    continue
+                if entries:
+                    yield chrom, start, end, entries
+                chrom = chr
+                start = end = pos
+                entries = set(es)
+            if entries:
+                yield chrom, start, end, entries
+
+        for (chr, start, end, entries) in chunked(pair_alns, self.interval):
+            for aln in bam_reader.fetch(chr, start, end + 1):
+                locus = (aln.reference_name, aln.reference_start)
+                entry = (aln.query_name, aln.is_read1)
+                if not aln.is_secondary and entry in entries:
+                    yield aln
+
+    def split_alignment(self, aln, splicing_start):
+        elems = aln.cigartuples
+        blocks = aln.get_blocks()
+
+        elem_idx = 0
+        block_idx = 0
+        for op, len in elems:
+            if op == 0:
+                _, block_end = blocks[block_idx]
+                if block_end == splicing_start: break
+                block_idx += 1
+            elem_idx += 1
+
+        elems1 = elems[:elem_idx+1]
+        elems2 = list(itertools.dropwhile(lambda elem: elem[0] != 0, elems[elem_idx+1:]))
+        count_bases = lambda ops, elems: sum(e[1] for e in elems if e[0] in ops)
+
+        aln1 = copy.copy(aln)
+        aln2 = copy.copy(aln)
+        prim_flag, suppl_flag = aln.flag & ~0x100, aln.flag | 0x100
+        # Consider alignment with more matched bases as primary and the other as supplementary
+        if count_bases({0}, elems1) >= count_bases({0}, elems2):
+            aln1.flag, aln2.flag = prim_flag, suppl_flag
+        else:
+            aln1.flag, aln2.flag = suppl_flag, prim_flag
+        aln2.reference_start = blocks[block_idx+1][0]
+        # To reset CIGAR (and related properties), .cigartuples must be set to None first
+        aln1.cigartuples = None; aln1.cigartuples = elems1 + [(4, count_bases({0, 1, 4}, elems2))]
+        aln2.cigartuples = None; aln2.cigartuples = [(4, count_bases({0, 1, 4}, elems1))] + elems2
+        aln1.template_length, aln2.template_length = \
+            (aln.template_length, 0) if aln.template_length >= 0 else (0, aln.template_length)
+        return (aln1, aln2)


### PR DESCRIPTION
**Note:** This PR is just for a preliminary review prior to the ongoing PR to the upstream and intended to be closed without being merged once approved.

This PR proposes a revised version of #3 to respect the Genomon team's requests.

Two primary differences are that:
- Two new CLI options (`--star_sj_tab` and `--star_aligned_bam`) are added to specify the file paths to `SJ.out.tab` and `Aligned.sortedByCoord.out.bam` respectively, in addition to the existing option `--star`
- A new result file named `fusion_fusion.result.traced.txt` is added to make it possible to identify whether each reported variant comes from `Chimeric.out.sam` or `SJ.out.tab`

There should be no essential differences that affect the analysis results (Especially, the implementation of the `ShortRangeChimeraFilter` class is exactly the same as before).

The first one is for consistency with the semantics of the `--star` option and preserves fusionfusion's backward compatibility.

The second one is a little bit complicated, so let me elaborate on that below.

The following figure illustrates the process flow among fusionfusion's file formats, including this modification. Later descriptions will be based on this (in which, an arrow, say `A` -> `B`, denotes the file `B` is generated from the file `A`):

![fusionfusion_pr_short_range_chimera_filter_flow](https://user-images.githubusercontent.com/27441/111404186-ace7d380-8711-11eb-8f9c-686b87428b92.png)

The format of `fusion_fusion.result.traced.txt` (internally called the *traced file*) is almost identical to that of `fusion_fusion.result.txt`, except that the former has one extra column on the right end to represent where the variant on that line comes from. The value of that column is called the *source* of the variant, and the possible values of the source are as follows:

| source value | meaning |
|:-------------|:---------|
| `Chimeric` | The variant comes from `Chimeric.out.sam` |
| `SJ` | The variant comes from `SJ.out.tab` |
| `SJ,Chimeric` | The variant comes from both `SJ.out.tab` and `Chimeric.out.sam` |
| `---` | Unknown (This value only appears when using another aligner other than STAR) |

This change also adds another file named `star.chimeric.trace.txt` (internally called the *trace file*). `star.chimeric.trace.txt` is an intermediate file used to help generate `fusion_fusion.result.traced.txt` from `fusion_fusion.result.txt`, and it has the following format:

```
<chr1> <pos1> <strand1> <chr2> <pos2> <strand2> <inserted seq> <source>
```

The combination of columns other than `<source>` has sufficient information to identify the variants listed in `fusion_fusion.result.txt`, so it can be used to [map each variant to its source one-to-one](https://github.com/chrovis-genomon/fusionfusion/blob/01aed4fecfe737b23278be4d090b9b1435850750/fusionfusion/annotationFunction.py#L284-L298).

To trace the source information, [the QNAME of each line is modified a bit](https://github.com/chrovis-genomon/fusionfusion/blob/01aed4fecfe737b23278be4d090b9b1435850750/fusionfusion/parseJunctionInfo.py#L412-L416) in the files generated up to `star.chimeric.clustered.filt2.txt` (*). The QNAME of each line in `star.chimeric.tmp1.txt` will be [suffixed with `@Chimeric`](https://github.com/chrovis-genomon/fusionfusion/blob/01aed4fecfe737b23278be4d090b9b1435850750/fusionfusion/run.py#L157-L159) whereas those in `star.chimeric.tmp2.txt` will be [suffixed with `@SJ`](https://github.com/chrovis-genomon/fusionfusion/blob/01aed4fecfe737b23278be4d090b9b1435850750/fusionfusion/run.py#L180-L182). I've confirmed that no conversions between `star.chimeric.txt` and `star.chimeric.clustered.filt2.txt` interpret QNAMEs in their own way and further steps after `star.chimeric.clustered.splicing.txt` are never affected by that modification.

(*) The reason for embedding the source information in QNAMEs is that it would otherwise be hard to trace the conversion from `star.chimeric.txt` to `star.chimeric.clustered.txt` because multiple lines in the former format will be aggregated into a single line in the latter.